### PR TITLE
Fixing impersonate token replacement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -525,16 +525,11 @@ function attachRoadwayOptionHandlers(roadwayMessageId: number) {
 
     const impersonate = globalContext.substituteParams(
       preset.impersonate,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
       {
-        roadwaySelected: message.extra?.[KEYS.EXTRA.OPTIONS]?.[index],
-      },
-      undefined,
+        dynamicMacros: { roadwaySelected: message.extra?.[KEYS.EXTRA.OPTIONS]?.[index] }
+      }
     );
+    
     if (settings.impersonateApi === 'profile') {
       if (!settings.impersonateProfileId) {
         await st_echo('error', 'Please select an impersonation connection profile in the settings.');


### PR DESCRIPTION
The `{{roadwaySelected}}` token was not being replaced when selecting an option in "Impersonate" mode. It appears to be the result of a breaking change in a recent update to the API. This corrects the issue. I have no idea if it causes other issues or if there are similar instances where the issue still occurs. Be forewarned!

Fixes #9 